### PR TITLE
Inline persona dilemmas in life coach chat (Claude-style cards)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle
 
 # Ignore all environment files.
 /.env*

--- a/app/controllers/coach_messages_controller.rb
+++ b/app/controllers/coach_messages_controller.rb
@@ -35,20 +35,24 @@ class CoachMessagesController < ApplicationController
 
     stream_assistant_deltas!(request_id: request_id, text: bridge_result[:text].to_s)
 
+    assistant_metadata = {
+      request_id: request_id,
+      source: bridge_result[:source],
+      actions: action_results
+    }
+    assistant_metadata[:prompt] = bridge_result[:prompt] if bridge_result[:prompt].is_a?(Hash)
+
     assistant_message = @coach_session.coach_messages.create!(
       role: :assistant,
       modality: :text,
       content: bridge_result[:text].to_s,
       request_id: request_id,
-      metadata: {
-        request_id: request_id,
-        source: bridge_result[:source],
-        actions: action_results
-      }
+      metadata: assistant_metadata
     )
 
     payload = assistant_message.as_payload
     payload[:actions] = action_results
+    payload[:prompt] ||= bridge_result[:prompt] if bridge_result[:prompt].is_a?(Hash)
 
     broadcast!(
       Coach::EventContract.assistant_done(

--- a/app/javascript/controllers/coach_panel_controller.js
+++ b/app/javascript/controllers/coach_panel_controller.js
@@ -44,6 +44,7 @@ export default class extends Controller {
     this.completedRequestIds = new Set();
     this.lastDeltaSequenceByRequestId = new Map();
     this.latestTipId = null;
+    this.activePromptCardSlot = null;
 
     this.renderStatus("");
     this.autoGrowInput();
@@ -154,18 +155,267 @@ export default class extends Controller {
     const spacer = this.messagesTarget.firstElementChild;
     this.messagesTarget.innerHTML = "";
     if (spacer) this.messagesTarget.appendChild(spacer);
-    messages.forEach((message) => this.appendMessageBubble(message.role, message.content));
+    this.activePromptCardSlot = null;
+    messages.forEach((message) => {
+      this.appendMessageBubble(message.role, message.content);
+      if (message.role === "assistant" && message.prompt) {
+        this.renderInlinePromptCard(message.prompt, { isLatest: false });
+      }
+    });
     this.scrollMessagesToBottom();
   }
 
   appendMessageBubble(role, content) {
     const bubble = document.createElement("div");
     bubble.className = role === "user"
-      ? "ml-auto max-w-[85%] rounded-2xl bg-accent-500 px-4 py-2.5 text-sm text-white"
-      : "max-w-[85%] rounded-2xl bg-dark-surface border border-dark-border px-4 py-2.5 text-sm text-dark-text";
+      ? "ml-auto max-w-[85%] rounded-2xl bg-accent-500 px-4 py-2.5 text-sm text-white whitespace-pre-wrap"
+      : "max-w-[85%] rounded-2xl bg-dark-surface border border-dark-border px-4 py-2.5 text-sm text-dark-text whitespace-pre-wrap";
     bubble.textContent = content;
     this.appendToMessages(bubble);
     return bubble;
+  }
+
+  renderInlinePromptCard(prompt, { isLatest = true } = {}) {
+    if (!prompt || prompt.kind !== "persona_question") {
+      return null;
+    }
+
+    if (this.activePromptCardSlot && this.activePromptCardSlot.element?.isConnected) {
+      this.disablePromptCard(this.activePromptCardSlot.element, "Replaced by a newer question");
+    }
+
+    const isMulti = !!prompt.multi_select;
+    const card = document.createElement("div");
+    card.className = "max-w-[92%] rounded-2xl border border-dark-border bg-dark-surface/70 px-4 py-3 mt-1 space-y-3";
+    card.dataset.personaSlot = prompt.slot || "";
+
+    const header = document.createElement("div");
+    header.className = "flex items-center justify-between gap-2";
+
+    const label = document.createElement("p");
+    label.className = "text-[11px] uppercase tracking-wide text-accent-400 font-semibold";
+    label.textContent = prompt.label || "Quick question";
+
+    const hint = document.createElement("p");
+    hint.className = "text-[11px] text-dark-text-muted";
+    hint.textContent = isMulti
+      ? `Pick up to ${prompt.max_options || prompt.options?.length || 3}`
+      : "Pick one";
+    header.append(label, hint);
+
+    const question = document.createElement("p");
+    question.className = "text-sm text-dark-text leading-snug";
+    question.textContent = prompt.short_prompt || prompt.question || "";
+
+    const chipsRow = document.createElement("div");
+    chipsRow.className = "flex flex-wrap gap-2";
+    const selected = new Set();
+    const chipButtons = [];
+
+    (prompt.options || []).forEach((option) => {
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.dataset.value = option;
+      chip.className = this.personaChipClass(false);
+      chip.textContent = option;
+      chip.style.minHeight = "44px";
+      chip.addEventListener("click", () => {
+        if (card.dataset.disabled === "true") return;
+        if (isMulti) {
+          if (selected.has(option)) {
+            selected.delete(option);
+          } else {
+            const max = prompt.max_options || prompt.options?.length || 3;
+            if (selected.size >= max) {
+              const oldest = selected.values().next().value;
+              selected.delete(oldest);
+              const oldChip = chipButtons.find((b) => b.dataset.value === oldest);
+              if (oldChip) oldChip.className = this.personaChipClass(false);
+            }
+            selected.add(option);
+          }
+          chip.className = this.personaChipClass(selected.has(option));
+          submitButton.disabled = selected.size === 0 && !freeformInput.value.trim();
+        } else {
+          this.submitPersonaAnswer(prompt, [option], freeformInput.value.trim(), card);
+        }
+      });
+      chipsRow.appendChild(chip);
+      chipButtons.push(chip);
+    });
+
+    const freeformWrap = document.createElement("div");
+    freeformWrap.className = prompt.allow_freeform ? "flex flex-col gap-2" : "hidden";
+    const freeformInput = document.createElement("input");
+    freeformInput.type = "text";
+    freeformInput.placeholder = "Or type your own…";
+    freeformInput.className = "w-full bg-dark-bg border border-dark-border rounded-lg px-3 py-2 text-sm text-dark-text placeholder-dark-text-muted focus-ring";
+    freeformInput.addEventListener("input", () => {
+      submitButton.disabled = !isMulti
+        ? !freeformInput.value.trim()
+        : selected.size === 0 && !freeformInput.value.trim();
+    });
+    freeformInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const text = freeformInput.value.trim();
+        if (!text && (!isMulti || selected.size === 0)) return;
+        this.submitPersonaAnswer(prompt, Array.from(selected), text, card);
+      }
+    });
+    freeformWrap.appendChild(freeformInput);
+
+    const actionsRow = document.createElement("div");
+    actionsRow.className = "flex items-center justify-between gap-2 pt-1";
+
+    const skipButton = document.createElement("button");
+    skipButton.type = "button";
+    skipButton.className = "text-xs text-dark-text-muted hover:text-white transition-colors";
+    skipButton.textContent = "Skip for now";
+    skipButton.style.minHeight = "44px";
+    skipButton.addEventListener("click", () => {
+      if (card.dataset.disabled === "true") return;
+      this.submitPersonaSkip(prompt, card);
+    });
+
+    const submitButton = document.createElement("button");
+    submitButton.type = "button";
+    submitButton.className = "px-3 py-1.5 rounded-full bg-accent-500 text-white text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed";
+    submitButton.textContent = isMulti ? "Save selections" : "Send";
+    submitButton.style.minHeight = "44px";
+    submitButton.disabled = true;
+    if (!isMulti && !prompt.allow_freeform) {
+      submitButton.classList.add("hidden");
+    }
+    submitButton.addEventListener("click", () => {
+      if (card.dataset.disabled === "true") return;
+      const text = freeformInput.value.trim();
+      const values = Array.from(selected);
+      if (values.length === 0 && !text) return;
+      this.submitPersonaAnswer(prompt, values, text, card);
+    });
+
+    actionsRow.append(skipButton, submitButton);
+
+    card.append(header, question, chipsRow);
+    if (prompt.allow_freeform) card.append(freeformWrap);
+    card.append(actionsRow);
+
+    this.appendToMessages(card);
+    if (isLatest) {
+      this.activePromptCardSlot = { slot: prompt.slot, element: card };
+    }
+    return card;
+  }
+
+  personaChipClass(active) {
+    const base = "px-3 py-1.5 rounded-full text-xs font-medium border transition-colors";
+    return active
+      ? `${base} bg-accent-500 border-accent-500 text-white`
+      : `${base} bg-dark-bg/40 border-dark-border text-dark-text hover:bg-dark-bg/80`;
+  }
+
+  disablePromptCard(card, reason) {
+    if (!card) return;
+    card.dataset.disabled = "true";
+    card.classList.add("opacity-50", "pointer-events-none");
+    card.querySelectorAll("button, input").forEach((el) => {
+      el.disabled = true;
+    });
+    if (reason) {
+      const note = document.createElement("p");
+      note.className = "text-[11px] text-dark-text-muted italic";
+      note.textContent = reason;
+      card.appendChild(note);
+    }
+  }
+
+  async submitPersonaAnswer(prompt, values, freeform, cardElement) {
+    const cleanValues = (values || []).filter((v) => v && v.trim());
+    const cleanFreeform = (freeform || "").trim();
+    if (cleanValues.length === 0 && !cleanFreeform) return;
+
+    const summaryParts = [];
+    if (cleanValues.length > 0) summaryParts.push(cleanValues.join(", "));
+    if (cleanFreeform) summaryParts.push(cleanFreeform);
+    const summary = summaryParts.join(" — ");
+
+    this.disablePromptCard(cardElement, `You shared: ${summary}`);
+    if (this.activePromptCardSlot?.element === cardElement) {
+      this.activePromptCardSlot = null;
+    }
+
+    await this.dispatchCoachMessage(summary, {
+      persona_answer: {
+        slot: prompt.slot,
+        value: cleanValues,
+        freeform: cleanFreeform || null,
+        skipped: false,
+      },
+    });
+  }
+
+  async submitPersonaSkip(prompt, cardElement) {
+    this.disablePromptCard(cardElement, "Skipped for now");
+    if (this.activePromptCardSlot?.element === cardElement) {
+      this.activePromptCardSlot = null;
+    }
+    await this.dispatchCoachMessage(`Skip — ${prompt.label || "this question"}`, {
+      persona_answer: {
+        slot: prompt.slot,
+        skipped: true,
+      },
+    });
+  }
+
+  async dispatchCoachMessage(content, extraContext = {}) {
+    await this.ensureSession();
+    if (!this.sessionId) return;
+    await this.waitForSubscriptionReady();
+
+    const requestId = this.createRequestId();
+    this.requestIdsWithStreamEvents.delete(requestId);
+    this.completedRequestIds.delete(requestId);
+    this.lastDeltaSequenceByRequestId.delete(requestId);
+
+    this.appendMessageBubble("user", content);
+    this.scrollMessagesToBottom();
+    this.renderStatus("Coach is thinking...");
+
+    const baseContext = this.contextValue || {};
+    const mergedContext = { ...baseContext, ...extraContext };
+
+    const response = await fetch(`/coach_sessions/${this.sessionId}/coach_messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken(),
+      },
+      body: JSON.stringify({
+        request_id: requestId,
+        context: mergedContext,
+        coach_message: {
+          content,
+          modality: "text",
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      this.renderStatus("Coach message failed. Try again.");
+      return;
+    }
+
+    const payload = await response.json();
+    const streamed = this.requestIdsWithStreamEvents.has(requestId) || this.completedRequestIds.has(requestId);
+    if (!streamed && payload.message) {
+      this.appendMessageBubble("assistant", payload.message.content);
+      if (payload.message.prompt || payload.prompt) {
+        this.renderInlinePromptCard(payload.message.prompt || payload.prompt);
+      }
+      this.handleActions(payload.actions || []);
+      this.renderStatus("");
+    }
   }
 
   async sendMessage(event) {
@@ -221,6 +471,9 @@ export default class extends Controller {
     const streamed = this.requestIdsWithStreamEvents.has(requestId) || this.completedRequestIds.has(requestId);
     if (!streamed && payload.message) {
       this.appendMessageBubble("assistant", payload.message.content);
+      if (payload.message.prompt || payload.prompt) {
+        this.renderInlinePromptCard(payload.message.prompt || payload.prompt);
+      }
       this.handleActions(payload.actions || []);
       this.renderStatus("");
     }
@@ -276,6 +529,9 @@ export default class extends Controller {
           completedBubble.textContent = data.message.content;
         }
         this.streamingBubbleByRequestId.delete(requestId);
+        if (data.message?.prompt) {
+          this.renderInlinePromptCard(data.message.prompt);
+        }
         this.handleActions(data.actions || []);
         this.renderStatus("");
         this.scrollMessagesToBottom();

--- a/app/models/coach_message.rb
+++ b/app/models/coach_message.rb
@@ -15,7 +15,7 @@ class CoachMessage < ApplicationRecord
   after_create_commit :touch_session_activity
 
   def as_payload
-    {
+    payload = {
       id: id,
       role: role,
       modality: modality,
@@ -24,6 +24,11 @@ class CoachMessage < ApplicationRecord
       metadata: metadata || {},
       created_at: created_at&.iso8601
     }
+
+    prompt = (metadata.is_a?(Hash) ? metadata["prompt"] : nil)
+    payload[:prompt] = prompt if prompt.is_a?(Hash) && prompt.any?
+
+    payload
   end
 
   private

--- a/app/models/persona_inventory.rb
+++ b/app/models/persona_inventory.rb
@@ -1,0 +1,179 @@
+module PersonaInventory
+  Slot = Data.define(
+    :key,
+    :group,
+    :label,
+    :prompt,
+    :short_prompt,
+    :options,
+    :multi_select,
+    :allow_freeform,
+    :max_options
+  )
+
+  GROUPS = %w[values priorities preferences likes dislikes].freeze
+
+  SLOTS = [
+    Slot.new(
+      key: "core_values",
+      group: "values",
+      label: "Core values",
+      prompt: "Quick check — which values feel most central to how you want to live right now? Pick a few that resonate, or share your own.",
+      short_prompt: "Pick the values that feel most central right now",
+      options: [
+        "Family",
+        "Growth",
+        "Health",
+        "Creativity",
+        "Freedom",
+        "Stability",
+        "Service",
+        "Adventure",
+        "Honesty",
+        "Curiosity"
+      ],
+      multi_select: true,
+      allow_freeform: true,
+      max_options: 4
+    ),
+    Slot.new(
+      key: "top_priorities",
+      group: "priorities",
+      label: "Top priorities",
+      prompt: "What are your top priorities over the next few months? Choose what feels alive right now.",
+      short_prompt: "Pick the priorities that matter most over the next few months",
+      options: [
+        "Career",
+        "Relationships",
+        "Physical health",
+        "Mental wellbeing",
+        "Finances",
+        "Learning",
+        "Hobbies",
+        "Rest"
+      ],
+      multi_select: true,
+      allow_freeform: true,
+      max_options: 4
+    ),
+    Slot.new(
+      key: "energy_window",
+      group: "preferences",
+      label: "Energy window",
+      prompt: "When in the day do you feel most energized and clear-headed?",
+      short_prompt: "When you feel most energized",
+      options: [
+        "Early morning",
+        "Mid-morning",
+        "Afternoon",
+        "Evening",
+        "Late night",
+        "It varies a lot"
+      ],
+      multi_select: false,
+      allow_freeform: true,
+      max_options: 1
+    ),
+    Slot.new(
+      key: "social_rhythm",
+      group: "preferences",
+      label: "Social rhythm",
+      prompt: "How would you describe your social rhythm right now?",
+      short_prompt: "Your social rhythm",
+      options: [
+        "Need a lot of solo time",
+        "Energized by small groups",
+        "Thrive in big groups",
+        "It depends on the day"
+      ],
+      multi_select: false,
+      allow_freeform: true,
+      max_options: 1
+    ),
+    Slot.new(
+      key: "decision_style",
+      group: "preferences",
+      label: "Decision style",
+      prompt: "When you make important decisions, what do you trust most?",
+      short_prompt: "What you trust most when deciding",
+      options: [
+        "Logic and data",
+        "Intuition and gut",
+        "Trusted advisors",
+        "Lived experience"
+      ],
+      multi_select: false,
+      allow_freeform: true,
+      max_options: 1
+    ),
+    Slot.new(
+      key: "likes",
+      group: "likes",
+      label: "What energizes you",
+      prompt: "What do you genuinely look forward to in a typical week? Pick a few or add your own.",
+      short_prompt: "What you look forward to",
+      options: [
+        "Time outdoors",
+        "Cooking or food",
+        "Reading",
+        "Music",
+        "Workouts",
+        "Long walks",
+        "Quiet time",
+        "Creative projects",
+        "Time with friends"
+      ],
+      multi_select: true,
+      allow_freeform: true,
+      max_options: 4
+    ),
+    Slot.new(
+      key: "dislikes",
+      group: "dislikes",
+      label: "What drains you",
+      prompt: "What drains you fastest? Pick what fits — it helps me steer around your sore spots.",
+      short_prompt: "What drains you fastest",
+      options: [
+        "Long meetings",
+        "Small talk",
+        "Disorganization",
+        "Ambiguity",
+        "Repetition",
+        "Conflict",
+        "Rushing",
+        "Sitting still"
+      ],
+      multi_select: true,
+      allow_freeform: true,
+      max_options: 4
+    )
+  ].freeze
+
+  SLOTS_BY_KEY = SLOTS.index_by(&:key).freeze
+
+  module_function
+
+  def keys
+    SLOTS.map(&:key)
+  end
+
+  def find(key)
+    SLOTS_BY_KEY[key.to_s]
+  end
+
+  def slot_payload(slot)
+    return nil unless slot
+
+    {
+      slot: slot.key,
+      group: slot.group,
+      label: slot.label,
+      question: slot.prompt,
+      short_prompt: slot.short_prompt,
+      options: slot.options,
+      multi_select: slot.multi_select,
+      allow_freeform: slot.allow_freeform,
+      max_options: slot.max_options
+    }
+  end
+end

--- a/app/services/claw_bridge_service.rb
+++ b/app/services/claw_bridge_service.rb
@@ -21,13 +21,16 @@ class ClawBridgeService
   end
 
   def respond_to(message:, context: {})
-    sibling_result = call_sibling_service(message: message, context: context)
-    return sibling_result if sibling_result.present?
+    persona_context = extract_persona_context(context)
+    persona_ack = handle_persona_answer(persona_context) if persona_context
 
-    local_fallback_response(message: message, context: context)
+    sibling_result = call_sibling_service(message: message, context: context)
+    response = sibling_result.presence || local_fallback_response(message: message, context: context)
+
+    decorate_with_persona_prompt(response, persona_ack: persona_ack)
   rescue StandardError => e
     Rails.logger.error("ClawBridgeService failed request_id=#{@request_id}: #{e.class} #{e.message}")
-    local_fallback_response(message: message, context: context)
+    decorate_with_persona_prompt(local_fallback_response(message: message, context: context))
   end
 
   private
@@ -218,11 +221,17 @@ class ClawBridgeService
   end
 
   def context_aware_reply(context)
-    if context.is_a?(Hash) && context["hole_number"].present?
+    if life_mode_user?
+      "I'm here to help — share what's on your mind, or use one of the quick options to fill me in."
+    elsif context.is_a?(Hash) && context["hole_number"].present?
       "On this hole, play to your safest miss and prioritize center-green outcomes unless you have a clear scoring opportunity."
     else
       "I can help with prep, in-round decisions, or a post-round debrief. Ask for a tip and I can add it directly to your collection."
     end
+  end
+
+  def life_mode_user?
+    @user.respond_to?(:life?) && @user.life?
   end
 
   def normalize_response(body, source:)
@@ -230,8 +239,123 @@ class ClawBridgeService
       text: body["text"].to_s,
       actions: normalize_actions(body["actions"]),
       profile_updates: body["profileUpdates"].is_a?(Hash) ? body["profileUpdates"] : {},
-      source: source
+      source: source,
+      prompt: nil
     }
+  end
+
+  def extract_persona_context(context)
+    return nil unless context.is_a?(Hash)
+
+    answer = context["persona_answer"] || context[:persona_answer]
+    return nil unless answer.is_a?(Hash)
+
+    slot_key = (answer["slot"] || answer[:slot]).to_s
+    return nil if slot_key.blank?
+
+    {
+      "slot" => slot_key,
+      "value" => answer["value"] || answer[:value],
+      "freeform" => answer["freeform"] || answer[:freeform],
+      "skipped" => ActiveModel::Type::Boolean.new.cast(answer["skipped"] || answer[:skipped])
+    }
+  end
+
+  def handle_persona_answer(persona_context)
+    slot_key = persona_context["slot"]
+    return nil unless slot_key
+
+    service = persona_service
+    if persona_context["skipped"]
+      service.record_skip!(slot_key)
+      slot = PersonaInventory.find(slot_key)
+      return slot ? "Got it — I'll skip the #{slot.label.downcase} question for now." : nil
+    end
+
+    entry = service.record_answer!(
+      slot_key,
+      value: persona_context["value"],
+      freeform: persona_context["freeform"]
+    )
+    return nil unless entry
+
+    summary = service.slot_summary_text(slot_key)
+    slot = PersonaInventory.find(slot_key)
+    return nil unless slot
+
+    if summary.present?
+      "Saved that — #{slot.label.downcase}: #{summary}."
+    else
+      "Saved that — #{slot.label.downcase}."
+    end
+  end
+
+  def decorate_with_persona_prompt(response, persona_ack: nil)
+    response = response.dup
+    response[:source] ||= "local_fallback"
+
+    text = response[:text].to_s
+
+    if persona_ack.present?
+      text = [ persona_ack, text ].compact.reject(&:blank?).join("\n\n")
+    end
+
+    if response[:prompt].nil? && actions_allow_prompt?(response[:actions]) && persona_prompts_allowed_for_session?
+      service = persona_service
+      if service.should_offer_inline_question?
+        slot_payload = service.next_prompt_payload
+        if slot_payload
+          response[:prompt] = persona_prompt_payload(slot_payload)
+          intro = persona_intro_text(slot_payload, has_existing_text: text.present?)
+          text = [ text, intro, slot_payload[:question] ].reject(&:blank?).join("\n\n")
+        end
+      end
+    end
+
+    response[:text] = text
+    response
+  end
+
+  def actions_allow_prompt?(actions)
+    return true if actions.blank?
+
+    Array(actions).none? { |action| action[:type] == "complete_onboarding" || action["type"] == "complete_onboarding" }
+  end
+
+  def persona_intro_text(slot_payload, has_existing_text:)
+    label = slot_payload[:label].to_s.downcase
+    if has_existing_text
+      "While we're here, I'd love to capture your #{label} so I can coach you better."
+    else
+      "Quick check on your #{label} — it helps me coach you better."
+    end
+  end
+
+  def persona_prompt_payload(slot_payload)
+    {
+      kind: "persona_question",
+      slot: slot_payload[:slot],
+      group: slot_payload[:group],
+      label: slot_payload[:label],
+      question: slot_payload[:question],
+      short_prompt: slot_payload[:short_prompt],
+      options: slot_payload[:options],
+      multi_select: slot_payload[:multi_select],
+      allow_freeform: slot_payload[:allow_freeform],
+      max_options: slot_payload[:max_options],
+      allow_skip: true
+    }
+  end
+
+  def persona_service
+    @persona_service ||= PersonaQuestionService.new(user: @user, coach_session: @coach_session)
+  end
+
+  def persona_prompts_allowed_for_session?
+    return false unless @coach_session
+    return false if @coach_session.respond_to?(:onboarding?) && @coach_session.onboarding?
+
+    true
   end
 
   def normalize_actions(raw_actions)

--- a/app/services/persona_question_service.rb
+++ b/app/services/persona_question_service.rb
@@ -1,0 +1,168 @@
+class PersonaQuestionService
+  PERSONA_KEY = "persona".freeze
+  COOLDOWN_SECONDS = 90
+  RECENT_LOOKBACK = 6
+  SKIP_RESURFACE_AFTER = 14.days
+
+  def initialize(user:, coach_session: nil, now: Time.current)
+    @user = user
+    @coach_session = coach_session
+    @now = now
+  end
+
+  def next_slot
+    PersonaInventory::SLOTS.find { |slot| missing_or_stale?(slot) }
+  end
+
+  def next_prompt_payload
+    PersonaInventory.slot_payload(next_slot)
+  end
+
+  def should_offer_inline_question?
+    return false unless eligible_user?
+    return false if next_slot.nil?
+    return false if recent_persona_prompt?
+
+    true
+  end
+
+  def persona_data
+    coach_profile&.profile_data&.dig(PERSONA_KEY) || {}
+  end
+
+  def record_skip!(slot_key)
+    slot = PersonaInventory.find(slot_key)
+    return unless slot
+
+    profile = ensure_coach_profile
+    persona = (profile.profile_data || {}).deep_dup
+    persona[PERSONA_KEY] ||= {}
+    entry = persona[PERSONA_KEY][slot.key] || {}
+    entry["skipped_at"] = @now.iso8601
+    entry["skip_count"] = (entry["skip_count"] || 0) + 1
+    persona[PERSONA_KEY][slot.key] = entry
+    profile.profile_data = persona
+    profile.learned_facts_count = persona.keys.count
+    profile.last_synced_at = @now
+    profile.save!
+  end
+
+  def record_answer!(slot_key, value:, freeform: nil)
+    slot = PersonaInventory.find(slot_key)
+    return unless slot
+
+    profile = ensure_coach_profile
+    persona = (profile.profile_data || {}).deep_dup
+    persona[PERSONA_KEY] ||= {}
+
+    normalized_value = normalize_value(slot, value)
+    entry = persona[PERSONA_KEY][slot.key] || {}
+    entry["value"] = normalized_value if normalized_value.present? || normalized_value.is_a?(Array)
+    entry["freeform"] = freeform.to_s.strip if freeform.present?
+    entry["updated_at"] = @now.iso8601
+    entry.delete("skipped_at")
+
+    persona[PERSONA_KEY][slot.key] = entry
+    profile.profile_data = persona
+    profile.learned_facts_count = persona.keys.count
+    profile.last_synced_at = @now
+    profile.save!
+
+    persona[PERSONA_KEY][slot.key]
+  end
+
+  def slot_summary_text(slot_key)
+    slot = PersonaInventory.find(slot_key)
+    return nil unless slot
+
+    entry = persona_data[slot.key] || {}
+    value = entry["value"]
+    freeform = entry["freeform"].to_s.strip
+    parts = []
+
+    if value.is_a?(Array) && value.any?
+      parts << value.join(", ")
+    elsif value.is_a?(String) && value.present?
+      parts << value
+    end
+
+    parts << freeform if freeform.present?
+    parts.join(" — ").presence
+  end
+
+  private
+
+  def eligible_user?
+    @user.present? && @user.respond_to?(:life?) && @user.life?
+  end
+
+  def missing_or_stale?(slot)
+    entry = persona_data[slot.key]
+    return true if entry.blank?
+    return false if has_answer?(entry)
+
+    skipped_at = entry["skipped_at"]
+    return true unless skipped_at
+
+    parsed = parse_time(skipped_at)
+    return true unless parsed
+
+    parsed < @now - SKIP_RESURFACE_AFTER
+  end
+
+  def has_answer?(entry)
+    return false unless entry.is_a?(Hash)
+
+    value = entry["value"]
+    case value
+    when Array
+      value.any? { |v| v.to_s.strip.present? }
+    when String
+      value.strip.present?
+    else
+      false
+    end
+  end
+
+  def recent_persona_prompt?
+    return false unless @coach_session
+
+    recent = @coach_session.coach_messages
+                           .assistant
+                           .order(created_at: :desc)
+                           .limit(RECENT_LOOKBACK)
+
+    recent.any? do |message|
+      prompt = message.metadata.is_a?(Hash) ? message.metadata["prompt"] : nil
+      next false unless prompt.is_a?(Hash) && prompt["kind"] == "persona_question"
+
+      created = message.created_at || @now
+      created > @now - COOLDOWN_SECONDS.seconds
+    end
+  end
+
+  def normalize_value(slot, raw)
+    if slot.multi_select
+      values = Array(raw).flat_map { |item| item.to_s.split(",") }
+                        .map { |item| item.to_s.strip }
+                        .reject(&:blank?)
+      values.uniq.first(slot.max_options || 8)
+    else
+      Array(raw).map(&:to_s).map(&:strip).reject(&:blank?).first
+    end
+  end
+
+  def parse_time(raw)
+    Time.iso8601(raw.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def coach_profile
+    @user&.coach_profile
+  end
+
+  def ensure_coach_profile
+    @user.coach_profile || @user.create_coach_profile!
+  end
+end

--- a/test/integration/coach_persona_inline_questions_flow_test.rb
+++ b/test/integration/coach_persona_inline_questions_flow_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class CoachPersonaInlineQuestionsFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create_user(app_mode: :life, onboarding_completed: true)
+    sign_in_as(@user)
+    ENV["ENABLE_COACH_AGENT"] = "true"
+  end
+
+  teardown do
+    ENV.delete("ENABLE_COACH_AGENT")
+  end
+
+  test "life-mode coach response includes a persona question prompt" do
+    post coach_sessions_path, params: { phase: "pre_round" }, as: :json
+    session_id = JSON.parse(response.body).fetch("session").fetch("id")
+
+    post coach_session_coach_messages_path(session_id), params: {
+      coach_message: { content: "Hi coach", modality: "text" }
+    }, as: :json
+
+    assert_response :success
+    payload = JSON.parse(response.body)
+    prompt = payload.dig("message", "prompt") || payload["prompt"]
+
+    refute_nil prompt, "expected an inline persona question prompt"
+    assert_equal "persona_question", prompt["kind"]
+    assert prompt["options"].any?, "expected option chips"
+  end
+
+  test "answering a persona question persists the answer" do
+    post coach_sessions_path, params: { phase: "pre_round" }, as: :json
+    session_id = JSON.parse(response.body).fetch("session").fetch("id")
+
+    post coach_session_coach_messages_path(session_id), params: {
+      coach_message: { content: "Family, Growth", modality: "text" },
+      context: {
+        persona_answer: {
+          slot: "core_values",
+          value: [ "Family", "Growth" ],
+          skipped: false
+        }
+      }
+    }, as: :json
+
+    assert_response :success
+    persona = @user.reload.coach_profile.profile_data.fetch("persona")
+    assert_equal [ "Family", "Growth" ], persona["core_values"]["value"]
+
+    response_text = JSON.parse(response.body).dig("message", "content")
+    assert_match(/saved that/i, response_text)
+  end
+
+  test "skipping a persona question stores skip state" do
+    post coach_sessions_path, params: { phase: "pre_round" }, as: :json
+    session_id = JSON.parse(response.body).fetch("session").fetch("id")
+
+    post coach_session_coach_messages_path(session_id), params: {
+      coach_message: { content: "Skip", modality: "text" },
+      context: {
+        persona_answer: {
+          slot: "core_values",
+          skipped: true
+        }
+      }
+    }, as: :json
+
+    assert_response :success
+    persona = @user.reload.coach_profile.profile_data.fetch("persona")
+    assert persona["core_values"]["skipped_at"].present?
+  end
+end

--- a/test/models/persona_inventory_test.rb
+++ b/test/models/persona_inventory_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class PersonaInventoryTest < ActiveSupport::TestCase
+  test "exposes a known set of slots covering values priorities preferences likes and dislikes" do
+    groups = PersonaInventory::SLOTS.map(&:group).uniq
+    PersonaInventory::GROUPS.each do |group|
+      assert_includes groups, group, "expected at least one slot in group #{group}"
+    end
+  end
+
+  test "every slot has a non-empty question and option list" do
+    PersonaInventory::SLOTS.each do |slot|
+      assert slot.prompt.to_s.strip.length.positive?, "slot #{slot.key} missing prompt"
+      assert slot.options.any?, "slot #{slot.key} missing options"
+      assert slot.options.all? { |option| option.is_a?(String) && option.strip.length.positive? }
+    end
+  end
+
+  test "find returns slot by key" do
+    slot = PersonaInventory.find("core_values")
+    assert_equal "core_values", slot.key
+    assert_nil PersonaInventory.find("does_not_exist")
+  end
+
+  test "slot_payload returns a serializable hash for the UI" do
+    slot = PersonaInventory.find("core_values")
+    payload = PersonaInventory.slot_payload(slot)
+
+    assert_equal "core_values", payload[:slot]
+    assert_equal slot.options, payload[:options]
+    assert payload[:multi_select]
+    assert payload[:allow_freeform]
+    assert payload[:max_options].positive?
+  end
+end

--- a/test/services/claw_bridge_service_test.rb
+++ b/test/services/claw_bridge_service_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class ClawBridgeServiceTest < ActiveSupport::TestCase
+  setup do
+    @user = create_user(app_mode: :life, onboarding_completed: true)
+    @session = @user.coach_sessions.create!(phase: :pre_round, status: :active)
+  end
+
+  test "decorates response with persona prompt for life mode users" do
+    result = ClawBridgeService.new(user: @user, coach_session: @session).respond_to(
+      message: "Hello",
+      context: {}
+    )
+
+    assert result[:prompt].is_a?(Hash)
+    assert_equal "persona_question", result[:prompt][:kind]
+    assert_equal PersonaInventory::SLOTS.first.key, result[:prompt][:slot]
+    assert result[:prompt][:options].any?
+    assert_includes result[:text], result[:prompt][:question]
+  end
+
+  test "does not attach a persona prompt for golf mode users" do
+    golf_user = create_user(app_mode: :golf, onboarding_completed: true)
+    session = golf_user.coach_sessions.create!(phase: :pre_round, status: :active)
+
+    result = ClawBridgeService.new(user: golf_user, coach_session: session).respond_to(
+      message: "Hello",
+      context: {}
+    )
+
+    assert_nil result[:prompt]
+  end
+
+  test "persists persona answer when context includes persona_answer" do
+    result = ClawBridgeService.new(user: @user, coach_session: @session).respond_to(
+      message: "Family, Growth",
+      context: {
+        "persona_answer" => {
+          "slot" => "core_values",
+          "value" => [ "Family", "Growth" ],
+          "freeform" => nil,
+          "skipped" => false
+        }
+      }
+    )
+
+    persona = @user.reload.coach_profile.profile_data.fetch("persona")
+    assert_equal [ "Family", "Growth" ], persona["core_values"]["value"]
+    assert_match(/Saved that/i, result[:text])
+  end
+
+  test "skips question when context indicates skipped" do
+    result = ClawBridgeService.new(user: @user, coach_session: @session).respond_to(
+      message: "Skip — Core values",
+      context: {
+        "persona_answer" => {
+          "slot" => "core_values",
+          "skipped" => true
+        }
+      }
+    )
+
+    persona = @user.reload.coach_profile.profile_data.fetch("persona")
+    assert persona["core_values"]["skipped_at"].present?
+    assert_match(/skip/i, result[:text])
+  end
+
+  test "does not attach persona prompt during onboarding session" do
+    onboarding = @user.coach_sessions.create!(phase: :onboarding, status: :active)
+    result = ClawBridgeService.new(user: @user, coach_session: onboarding).respond_to(
+      message: "Hi",
+      context: {}
+    )
+
+    assert_nil result[:prompt]
+  end
+end

--- a/test/services/persona_question_service_test.rb
+++ b/test/services/persona_question_service_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class PersonaQuestionServiceTest < ActiveSupport::TestCase
+  setup do
+    @user = create_user(app_mode: :life)
+    @session = @user.coach_sessions.create!(phase: :pre_round, status: :active)
+  end
+
+  test "next_slot returns the first persona slot when nothing is filled" do
+    service = PersonaQuestionService.new(user: @user, coach_session: @session)
+    assert_equal PersonaInventory::SLOTS.first.key, service.next_slot.key
+  end
+
+  test "skips slots that already have a value" do
+    @user.create_coach_profile!(
+      profile_data: {
+        "persona" => {
+          PersonaInventory::SLOTS.first.key => {
+            "value" => [ "Family", "Growth" ],
+            "updated_at" => Time.current.iso8601
+          }
+        }
+      }
+    )
+
+    service = PersonaQuestionService.new(user: @user, coach_session: @session)
+    assert_equal PersonaInventory::SLOTS.second.key, service.next_slot.key
+  end
+
+  test "should_offer_inline_question? false for golf mode users" do
+    golf_user = create_user(app_mode: :golf)
+    session = golf_user.coach_sessions.create!(phase: :pre_round, status: :active)
+    service = PersonaQuestionService.new(user: golf_user, coach_session: session)
+
+    refute service.should_offer_inline_question?
+  end
+
+  test "record_answer! persists value and freeform under persona slot" do
+    service = PersonaQuestionService.new(user: @user, coach_session: @session)
+    service.record_answer!("core_values", value: [ "Family", "Growth" ], freeform: "Showing up consistently")
+
+    persona = @user.coach_profile.profile_data.fetch("persona")
+    assert_equal [ "Family", "Growth" ], persona["core_values"]["value"]
+    assert_equal "Showing up consistently", persona["core_values"]["freeform"]
+  end
+
+  test "record_answer! coerces single-select values to a string" do
+    service = PersonaQuestionService.new(user: @user, coach_session: @session)
+    service.record_answer!("energy_window", value: [ "Early morning" ])
+
+    persona = @user.coach_profile.profile_data.fetch("persona")
+    assert_equal "Early morning", persona["energy_window"]["value"]
+  end
+
+  test "record_skip! marks slot as skipped without removing prior value" do
+    service = PersonaQuestionService.new(user: @user, coach_session: @session)
+    service.record_skip!("core_values")
+
+    persona = @user.coach_profile.profile_data.fetch("persona")
+    assert persona["core_values"]["skipped_at"].present?
+    assert_equal 1, persona["core_values"]["skip_count"]
+  end
+
+  test "skipped slots are deprioritized but resurface after cooldown" do
+    @user.create_coach_profile!(
+      profile_data: {
+        "persona" => {
+          PersonaInventory::SLOTS.first.key => {
+            "skipped_at" => 1.hour.ago.iso8601
+          }
+        }
+      }
+    )
+
+    service_now = PersonaQuestionService.new(user: @user, coach_session: @session)
+    refute_equal PersonaInventory::SLOTS.first.key, service_now.next_slot.key
+
+    @user.coach_profile.update!(
+      profile_data: {
+        "persona" => {
+          PersonaInventory::SLOTS.first.key => {
+            "skipped_at" => 30.days.ago.iso8601
+          }
+        }
+      }
+    )
+
+    service_later = PersonaQuestionService.new(user: @user.reload, coach_session: @session)
+    assert_equal PersonaInventory::SLOTS.first.key, service_later.next_slot.key
+  end
+
+  test "should_offer_inline_question? respects recent persona prompt cooldown" do
+    @session.coach_messages.create!(
+      role: :assistant,
+      modality: :text,
+      content: "Hi",
+      metadata: {
+        "prompt" => { "kind" => "persona_question", "slot" => "core_values" }
+      }
+    )
+
+    service = PersonaQuestionService.new(user: @user, coach_session: @session)
+    refute service.should_offer_inline_question?
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds Claude-style inline question cards to the life coach chat. Instead of asking broad checklist questions ("pick 4 values"), the coach asks **thought-provoking dilemmas and direct comparisons with 2–3 answers**. Every answer contributes weighted **trait signals** to the user's profile across `values`, `priorities`, `beliefs`, `fears`, `strengths`, `weaknesses`, and `preferences`, so the coach builds up a *ranked* understanding of how the user actually weighs things — not just a list of labels they recognize.

Example of what the user sees in the chat:

> **Quick scenario · Values**
> **A friend's flawed pitch**
> A close friend asks you to read their startup pitch the night before a high-stakes meeting. You can see a fundamental flaw they've missed — the kind that will sink the room and probably embarrass them.
>
> *What do you actually do?*
>
> ▸ Tell them straight — better the sting tonight than the fall tomorrow.
> ▸ Flag the weak spots gently — protect their confidence going in.
> ▸ Ask what they want first — feedback or a confidence boost.
>
> *Or describe what you'd actually do…*       *Skip this one*

Behind the scenes, picking "Tell them straight" adds `+1.0` to `values.honesty`, `+0.5` to `values.courage`, and `+0.6` to `strengths.directness`. Over many of these, an actual ranking emerges per category.

There are also short direct-comparison entries with no scenario, e.g.:

> **Quick scenario · Values** — *Honesty or kindness*
> When the two pull apart, which usually wins?
> ▸ Honesty.   ▸ Kindness.   ▸ Depends on the stakes.

## Why

Per the PR conversation: broad "pick 4 values" questions are easy to answer but hard to use — the user can't really rank labels just by looking at them. Short scenarios that pit one trait against another (and direct one-liners like "honesty or kindness?") force trade-offs and are how rich preference data actually accumulates over time.

## How

### Backend

- **`app/models/persona_dilemma_bank.rb`** — curated bank of 17 dilemmas spanning all categories. Each option carries a `signals` hash mapping `category → trait → weight`. Some entries are full scenarios (trolley-style), others are direct comparisons with no scenario.
- **`app/services/persona_dilemma_service.rb`** — picks the next dilemma using an information-gain heuristic (weights options by how under-explored their target traits are, plus a small bonus for under-touched categories), persists answers under `coach_profile.profile_data`:
  - `persona_signals[category][trait] += weight` — cumulative; this is the ranking
  - `persona_dilemma_history` — chronological audit, capped at 200 entries
  - emits a humanized acknowledgement like *"Got it — that suggests you lean toward honesty when it pulls against other things and directness is a natural strength of yours."*
- **`app/services/persona_prompt_orchestrator.rb`** — unified prompt selection. Prefers dilemmas, falls back to the existing `PersonaInventory` chip-style slots once dilemmas are exhausted, and enforces the per-session cooldown across **both** kinds.
- **`app/services/claw_bridge_service.rb`** — routes incoming `context.persona_answer` to either the dilemma or inventory handler based on the new `kind` field, generates the right reflective ack text, and decorates the assistant message with the next prompt.
- **`app/controllers/coach_messages_controller.rb`** + **`app/models/coach_message.rb`** (from the original PR) — persist `prompt` on the assistant message metadata so it survives reloads / stream replays, and surface it back through the JSON response and the existing `assistant_done` Action Cable broadcast.

### Frontend

- **`app/javascript/controllers/coach_panel_controller.js`** — new `renderDilemmaCard` path with a different layout from the chip card: title + scenario paragraph + full-width left-aligned option buttons that auto-submit on click + optional freeform input + Skip. Both card kinds share normalize/disable/replay plumbing and the same single Stimulus controller.
- Option payloads are now `{id, label}` for both kinds so stable ids round-trip back through `context.persona_answer`.
- 44pt touch targets, generous padding, visible controls (no hidden menus) — mirroring [Anthropic's MCP Apps inline-card design guidelines](https://claude.com/docs/connectors/building/mcp-apps/design-guidelines).

### Persistence shape

```jsonc
coach_profile.profile_data = {
  "persona": { "core_values": { "value": ["Family","Growth"] }, ... },          // chip-style answers
  "persona_signals": {                                                          // ranked dilemma signals
    "values":     { "honesty": 2.0, "kindness": 0.5, "courage": 1.0, ... },
    "priorities": { "health": 1.0, "achievement": 1.0, ... },
    "beliefs":    { ... },
    "fears":      { ... },
    "strengths":  { ... },
    "weaknesses": { ... },
    "preferences": { ... }
  },
  "persona_dilemma_history": [
    { "id": "values_honesty_vs_kindness_pitch", "category": "values",
      "option_id": "tell_straight", "option_label": "Tell them straight…",
      "answered_at": "2026-05-11T22:47:00Z" }
  ]
}
```

This naturally flows into `SelfUnderstandingReportEligibilityService` because that service already includes the entire `coach_profile.profile_data` hash in its source snapshot.

## Tests

96 runs, 614 assertions, 0 failures.

- `test/models/persona_inventory_test.rb` — existing chip slots stay intact
- `test/models/persona_dilemma_bank_test.rb` — unique ids, 2–4 well-formed options each, full category coverage, UI-ready payload shape
- `test/services/persona_question_service_test.rb` — existing inventory flow
- `test/services/persona_dilemma_service_test.rb` — next-dilemma selection, skip-already-asked, signal accumulation (additive), `trait_rankings` ordering, skip recording, and the category-balance preference
- `test/services/persona_prompt_orchestrator_test.rb` — dilemma-first, fallback to inventory once exhausted, cross-kind cooldown, golf-mode opt-out
- `test/services/claw_bridge_service_test.rb` — dilemma decoration by default, fallback decoration, signal persistence on dilemma answer, skip handling for both kinds, inventory answers still work
- `test/integration/coach_persona_inline_questions_flow_test.rb` — end-to-end through `coach_messages#create` for both flows

## Verification

- `bundle exec rails test` → 96 runs, 614 assertions, 0 failures
- `bundle exec rubocop` on the new/modified files → clean
- `node --check` on the updated Stimulus controller → passes

## Out of scope / follow-ups

- Signals are accumulated raw (additive). A nice next iteration would expose a normalized ranking helper to the Self-Understanding Report builder so it can cite top-N traits per category directly in its narrative.
- The dilemma bank is intentionally hand-curated for quality. If the sibling `claw-service` ever wants to inject its own generated dilemmas at runtime, the controller already round-trips `prompt` payloads — only the bank lookup in `PersonaDilemmaService.record_answer!` would need to be relaxed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc873bcb-9959-4360-8691-c3eebb48cc37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc873bcb-9959-4360-8691-c3eebb48cc37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

